### PR TITLE
사용자 일정 구분

### DIFF
--- a/src/main/java/com/hash/harp/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/hash/harp/domain/plan/controller/PlanController.java
@@ -38,15 +38,21 @@ public class PlanController {
         commandPlanService.updateDetail(detailReqduestDto, id);
     }
 
-    @PutMapping("/day/{userId}")
+    @PutMapping("/day/{userId}/{title}")
     private void updatePlan(
             @PathVariable(name = "userId") Long userId,
-            @RequestBody PlanRequestDto planRequestDto) {
-        commandPlanService.updatePlan(planRequestDto, userId);
+            @RequestBody PlanRequestDto planRequestDto,
+            @PathVariable(name = "title") String title
+            ) {
+        commandPlanService.updatePlan(planRequestDto, userId, title);
     }
 
-    @DeleteMapping("/day/{userId}")
-    private void deletePlan(@PathVariable(name = "userId") Long userId) {
-        commandPlanService.deletePlan(userId);
+    @DeleteMapping("/day/{userId}/{title}")
+    private void deletePlan(
+            @PathVariable(name = "userId") Long userId,
+            @PathVariable(name = "title") String title
+    )
+    {
+        commandPlanService.deletePlan(userId, title);
     }
 }

--- a/src/main/java/com/hash/harp/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/hash/harp/domain/plan/repository/PlanRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
-    List<Plan> findByUserId(Long userId);
+    List<Plan> findByUserIdAndTitle(Long userId, String title);
 
 }

--- a/src/main/java/com/hash/harp/domain/plan/service/CommandPlanService.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/CommandPlanService.java
@@ -54,11 +54,13 @@ public class CommandPlanService {
         planUpdater.updateDetail(detailRequestDto, id);
     }
 
-    public void updatePlan(PlanRequestDto planRequestDto, Long userId) {
-        planUpdater.updatePlan(planRequestDto, userId);
+    public void updatePlan(
+            PlanRequestDto planRequestDto, Long userId, String title
+    ) {
+        planUpdater.updatePlan(planRequestDto, userId, title);
     }
 
-    public void deletePlan(Long userId) {
-        planDeleter.deletePlan(userId);
+    public void deletePlan(Long userId, String title) {
+        planDeleter.deletePlan(userId, title);
     }
 }

--- a/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanDeleter.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanDeleter.java
@@ -13,8 +13,8 @@ public class PlanDeleter {
 
     private final PlanRepository planRepository;
 
-    public void deletePlan(Long userId) {
-        List<Plan> plans = planRepository.findByUserId(userId);
+    public void deletePlan(Long userId, String title) {
+        List<Plan> plans = planRepository.findByUserIdAndTitle(userId, title);
         plans.forEach(plan -> planRepository.delete(plan));
     }
 

--- a/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanUpdater.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanUpdater.java
@@ -28,8 +28,10 @@ public class PlanUpdater {
         detail.updateDetail(detailRequestDto);
     }
 
-    public void updatePlan(PlanRequestDto planRequestDto, Long userId) {
-        List<Plan> plans = planRepository.findByUserId(userId);
+    public void updatePlan(
+            PlanRequestDto planRequestDto, Long userId, String title
+    ) {
+        List<Plan> plans = planRepository.findByUserIdAndTitle(userId, title);
         plans.forEach(plan -> plan.updatePlan(planRequestDto));
     }
 }


### PR DESCRIPTION
#### 📌 개요
사용자 일정 구분 후 수정, 삭제

#### 🔗 작업 내용
- 사용자가 여러개의 일정을 가질 때, 일정 제목과 사용자 id를 이용해 구분할 수 있도록 했어요

#### 🐳 반영 브랜치
- feat/plan -> develop

#### 🕶️ 테스트 결과


#### 🔅 기타