### PR TITLE
userId 전부 accessToken으로 변경

### DIFF
--- a/src/main/java/com/hash/harp/domain/image/controller/ImageController.java
+++ b/src/main/java/com/hash/harp/domain/image/controller/ImageController.java
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageController {
     private final CommandImageService commandImageService;
 
-    @PostMapping("/plan")
+    @PostMapping("/Header")
     @ResponseStatus(HttpStatus.CREATED)
     public ImageResponseDto uploadPlanImage(MultipartFile file) {
         return ImageResponseDto.from(

--- a/src/main/java/com/hash/harp/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/hash/harp/domain/plan/controller/PlanController.java
@@ -5,6 +5,8 @@ import com.hash.harp.domain.plan.controller.dto.request.PlanRequestDto;
 import com.hash.harp.domain.plan.controller.dto.response.PlanResponseDto;
 import com.hash.harp.domain.plan.service.CommandPlanService;
 import com.hash.harp.domain.plan.service.QueryPlanService;
+import com.hash.harp.global.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,9 +21,14 @@ public class PlanController {
 
     private final QueryPlanService queryPlanService;
 
+    private final JwtService jwtService;
+
     @PostMapping("/header")
-    private void createHeader(@RequestBody HeaderRequestDto headerRequestDto) {
-        commandPlanService.createHeader(headerRequestDto);
+    private void createHeader(HttpServletRequest request, @RequestBody HeaderRequestDto headerRequestDto) {
+        String token = request.getHeader("Authorization");
+        Long userId = jwtService.getUserIdFromToken(token);
+
+        commandPlanService.createHeader(headerRequestDto, userId);
     }
 
     @PostMapping("/day")

--- a/src/main/java/com/hash/harp/domain/plan/controller/dto/request/HeaderRequestDto.java
+++ b/src/main/java/com/hash/harp/domain/plan/controller/dto/request/HeaderRequestDto.java
@@ -1,7 +1,6 @@
 package com.hash.harp.domain.plan.controller.dto.request;
 
 public record HeaderRequestDto(
-        Long userId,
         String title,
         String d_day,
         String startDate,

--- a/src/main/java/com/hash/harp/domain/plan/service/CommandPlanService.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/CommandPlanService.java
@@ -2,8 +2,6 @@ package com.hash.harp.domain.plan.service;
 
 import com.hash.harp.domain.plan.controller.dto.request.HeaderRequestDto;
 import com.hash.harp.domain.plan.controller.dto.request.PlanRequestDto;
-import com.hash.harp.domain.plan.repository.HeaderRepository;
-import com.hash.harp.domain.plan.repository.PlanRepository;
 import com.hash.harp.domain.plan.service.implementation.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,8 +21,8 @@ public class CommandPlanService {
 
     private final HeaderUpdater headerUpdater;
 
-    public void createHeader(HeaderRequestDto headerRequestDto) {
-        headerCreator.createHeader(headerRequestDto);
+    public void createHeader(HeaderRequestDto headerRequestDto, Long userId) {
+        headerCreator.createHeader(headerRequestDto, userId);
     }
 
     public void creatPlan(PlanRequestDto planRequestDto) {

--- a/src/main/java/com/hash/harp/domain/plan/service/implementation/HeaderCreator.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/implementation/HeaderCreator.java
@@ -3,6 +3,9 @@ package com.hash.harp.domain.plan.service.implementation;
 import com.hash.harp.domain.plan.controller.dto.request.HeaderRequestDto;
 import com.hash.harp.domain.plan.domain.Header;
 import com.hash.harp.domain.plan.repository.HeaderRepository;
+import com.hash.harp.domain.user.domain.User;
+import com.hash.harp.domain.user.exception.UserNotFoundException;
+import com.hash.harp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,11 +13,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class HeaderCreator {
 
+    private final UserRepository userRepository;
+
     private final HeaderRepository headerRepository;
 
-    public void createHeader(HeaderRequestDto headerRequestDto) {
+    public void createHeader(HeaderRequestDto headerRequestDto, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
         Header header = Header.builder()
-                .userId(headerRequestDto.userId())
+                .userId(user.getId())
                 .title(headerRequestDto.title())
                 .d_day(headerRequestDto.d_day())
                 .startDay(headerRequestDto.startDate())

--- a/src/main/java/com/hash/harp/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/hash/harp/domain/survey/controller/SurveyController.java
@@ -29,8 +29,11 @@ public class SurveyController {
         commandSurveyService.createSurvey(surveyRequestDto, userId);
     }
 
-    @GetMapping("/{surveyId}")
-    public SurveyResponseDto readById(@PathVariable("surveyId") Long id) {
-        return SurveyResponseDto.from(querySurveyService.readById(id));
+    @GetMapping
+    public SurveyResponseDto readById(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        Long userId = jwtService.getUserIdFromToken(token);
+
+        return SurveyResponseDto.from(querySurveyService.readById(userId));
     }
 }

--- a/src/main/java/com/hash/harp/domain/user/controller/UserController.java
+++ b/src/main/java/com/hash/harp/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.hash.harp.domain.user.controller;
 
 import com.hash.harp.domain.user.controller.dto.UserRequestDto;
 import com.hash.harp.domain.user.service.CommandUserService;
+import com.hash.harp.global.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,13 +14,21 @@ public class UserController {
 
     private final CommandUserService commandUserService;
 
-    @PutMapping("/{id}")
-    public void updateUserInfo(@PathVariable Long id, @RequestBody UserRequestDto userRequestDto) {
-        commandUserService.update(userRequestDto, id);
+    private final JwtService jwtService;
+
+    @PutMapping
+    public void updateUserInfo(HttpServletRequest request, @RequestBody UserRequestDto userRequestDto) {
+        String token = request.getHeader("Authorization");
+        Long userId = jwtService.getUserIdFromToken(token);
+
+        commandUserService.update(userRequestDto, userId);
     }
 
-    @PutMapping("/profile/{id}")
-    public void updateProfile(@PathVariable Long id, @RequestBody UserRequestDto userRequestDto) {
-        commandUserService.updateProfile(userRequestDto, id);
+    @PutMapping("/profile")
+    public void updateProfile(HttpServletRequest request,  @RequestBody UserRequestDto userRequestDto) {
+        String token = request.getHeader("Authorization");
+        Long userId = jwtService.getUserIdFromToken(token);
+
+        commandUserService.updateProfile(userRequestDto, userId);
     }
 }


### PR DESCRIPTION
#### 📌 개요
userId를 PathVariable이 아닌 header의 accessToken으로 받게 개선.

#### 🔗 작업 내용
- header에서 userId 꺼내와 user 객체에 넣어 사용

#### 🐳 반영 브랜치
- feat/token -> develop

#### 🕶️ 테스트 결과


#### 🔅 기타