### PR TITLE
일정 조회 하나만되게 수정

### DIFF
--- a/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanReader.java
+++ b/src/main/java/com/hash/harp/domain/plan/service/implementation/PlanReader.java
@@ -19,7 +19,7 @@ public class PlanReader {
     private final PlanRepository planRepository;
 
     public List<PlanResponseDto> readPlan(Long headerId) {
-        List<Plan> plans = planRepository.findAll();
+        List<Plan> plans = planRepository.findByHeaderId(headerId);
 
         return plans.stream()
                 .map(PlanResponseDto::from)


### PR DESCRIPTION
#### 📌 개요
일정 조회시 모든 일정이 조회되는 버그 수정했습니다.

#### 🔗 작업 내용
- findAll() -> findByHeaderId

#### 🐳 반영 브랜치
- feat/#47 -> develop

#### 🕶️ 테스트 결과


#### 🔅 기타